### PR TITLE
Fix default value of `max_seq_length`

### DIFF
--- a/dataset/prepare_data.py
+++ b/dataset/prepare_data.py
@@ -55,7 +55,7 @@ parser.add_argument(
 parser.add_argument(
     '-max_seq_length',
     dest='max_seq_length',
-    default=1025,
+    default=1024,
     type=int,
     help='Max sequence length',
 )


### PR DESCRIPTION
Default value of  `max_seq_length` in `prepare_data.py`(1025) if different with the one in `train_tpu.py`(1024). 
If not set  `--max_seq_length=1024` when running the file `prepare_data.py`, it may cause **`Can't parse serialized Example`**  #64 
